### PR TITLE
feat: replace `github.com/pkg/errors` with builtin errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,3 +19,9 @@ linters:
   - staticcheck
   disable:
   - structcheck
+
+linters-settings:
+  depguard:
+    list-type: 'denylist'
+    packages-with-error-message:
+      - 'github.com/pkg/errors': 'the github.com/pkg/errors is deprecated, use stdlib instead'

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,4 @@ go 1.19
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/matryer/is v1.4.0
-	github.com/pkg/errors v0.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,3 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=
 github.com/matryer/is v1.4.0/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/nextdns/allowlist.go
+++ b/nextdns/allowlist.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // allowlistAPIPath is the HTTP path for the allowlist API.
@@ -67,12 +65,12 @@ func (s *allowlistService) Create(ctx context.Context, request *CreateAllowlistR
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), allowlistAPIPath)
 	req, err := s.client.newRequest(http.MethodPut, path, request.Allowlist)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to create an allow list")
+		return fmt.Errorf("error creating request to create an allow list: %w", err)
 	}
 
 	err = s.client.do(ctx, req, nil)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to create an allow list")
+		return fmt.Errorf("error making a request to create an allow list: %w", err)
 	}
 
 	return nil
@@ -83,13 +81,13 @@ func (s *allowlistService) List(ctx context.Context, request *ListAllowlistReque
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), allowlistAPIPath)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to list the allow list")
+		return nil, fmt.Errorf("error creating request to list the allow list: %w", err)
 	}
 
 	response := allowlistResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to list the allow list")
+		return nil, fmt.Errorf("error making a request to list the allow list: %w", err)
 	}
 
 	return response.Allowlist, nil
@@ -100,12 +98,12 @@ func (s *allowlistService) Update(ctx context.Context, request *UpdateAllowlistR
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), allowlistIDAPIPath(request.ID))
 	req, err := s.client.newRequest(http.MethodPatch, path, request.Allowlist)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error creating request to update the allow list id: %s", request.ID))
+		return fmt.Errorf("error creating request to update the allow list id %s: %w", request.ID, err)
 	}
 
 	err = s.client.do(ctx, req, nil)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error making a request to update the allow list id: %s", request.ID))
+		return fmt.Errorf("error making a request to update the allow list id %s: %w", request.ID, err)
 	}
 
 	return nil

--- a/nextdns/denylist.go
+++ b/nextdns/denylist.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // denylistAPIPath is the HTTP path for the denylist API.
@@ -67,12 +65,12 @@ func (s *denylistService) Create(ctx context.Context, request *CreateDenylistReq
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), denylistAPIPath)
 	req, err := s.client.newRequest(http.MethodPut, path, request.Denylist)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to create an deny list")
+		return fmt.Errorf("error creating request to create an deny list: %w", err)
 	}
 
 	err = s.client.do(ctx, req, nil)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to create an deny list")
+		return fmt.Errorf("error making a request to create an deny list: %w", err)
 	}
 
 	return nil
@@ -83,13 +81,13 @@ func (s *denylistService) List(ctx context.Context, request *ListDenylistRequest
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), denylistAPIPath)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to list the deny list")
+		return nil, fmt.Errorf("error creating request to list the deny list: %w", err)
 	}
 
 	response := denylistResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to list the deny list")
+		return nil, fmt.Errorf("error making a request to list the deny list: %w", err)
 	}
 
 	return response.Denylist, nil
@@ -100,12 +98,12 @@ func (s *denylistService) Update(ctx context.Context, request *UpdateDenylistReq
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), denylistIDAPIPath(request.ID))
 	req, err := s.client.newRequest(http.MethodPatch, path, request.Denylist)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error creating request to update the deny list id: %s", request.ID))
+		return fmt.Errorf("error creating request to update the deny list id %s: %w", request.ID, err)
 	}
 
 	err = s.client.do(ctx, req, nil)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error making a request to update the deny list id: %s", request.ID))
+		return fmt.Errorf("error making a request to update the deny list id %s: %w", request.ID, err)
 	}
 
 	return nil

--- a/nextdns/parentalcontrol.go
+++ b/nextdns/parentalcontrol.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // parentalControlAPIPath is the HTTP path for the parental control settings API.
@@ -86,13 +84,13 @@ func (s *parentalControlService) Get(ctx context.Context, request *GetParentalCo
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), parentalControlAPIPath)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to get the parentalControl")
+		return nil, fmt.Errorf("error creating request to get the parentalControl: %w", err)
 	}
 
 	response := parentalControlResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to get the parentalControl")
+		return nil, fmt.Errorf("error making a request to get the parentalControl: %w", err)
 	}
 
 	return response.ParentalControl, nil
@@ -103,13 +101,13 @@ func (s *parentalControlService) Update(ctx context.Context, request *UpdatePare
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), parentalControlAPIPath)
 	req, err := s.client.newRequest(http.MethodPatch, path, request.ParentalControl)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to update the parentalControl")
+		return fmt.Errorf("error creating request to update the parentalControl: %w", err)
 	}
 
 	response := parentalControlResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to update the parentalControl")
+		return fmt.Errorf("error making a request to update the parentalControl: %w", err)
 	}
 
 	return nil

--- a/nextdns/parentalcontrol_categories.go
+++ b/nextdns/parentalcontrol_categories.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // parentalControlCategoriesAPIPath is the HTTP path for the parental control categories API.
@@ -68,13 +66,13 @@ func (s *parentalControlCategoriesService) Create(ctx context.Context, request *
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), parentalControlCategoriesAPIPath)
 	req, err := s.client.newRequest(http.MethodPut, path, request.ParentalControlCategories)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to create a parental control categories")
+		return fmt.Errorf("error creating request to create a parental control categories: %w", err)
 	}
 
 	response := parentalControlCategoriesResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to create a parental control categories")
+		return fmt.Errorf("error making a request to create a parental control categories: %w", err)
 	}
 
 	return nil
@@ -85,13 +83,13 @@ func (s *parentalControlCategoriesService) List(ctx context.Context, request *Li
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), parentalControlCategoriesAPIPath)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to list the parental control categories")
+		return nil, fmt.Errorf("error creating request to list the parental control categories: %w", err)
 	}
 
 	response := parentalControlCategoriesResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to list the parental control categories")
+		return nil, fmt.Errorf("error making a request to list the parental control categories: %w", err)
 	}
 
 	return response.ParentalControlCategories, nil
@@ -102,13 +100,13 @@ func (s *parentalControlCategoriesService) Update(ctx context.Context, request *
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), parentalControlCategoriesIDAPIPath(request.ID))
 	req, err := s.client.newRequest(http.MethodPatch, path, request.ParentalControlCategories)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to update the parental control categories")
+		return fmt.Errorf("error creating request to update the parental control categories: %w", err)
 	}
 
 	response := parentalControlCategoriesResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to update the parental control categories")
+		return fmt.Errorf("error making a request to update the parental control categories: %w", err)
 	}
 
 	return nil

--- a/nextdns/parentalcontrol_services.go
+++ b/nextdns/parentalcontrol_services.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // parentalControlServicesAPIPath is the HTTP path for the parental control services API.
@@ -68,13 +66,13 @@ func (s *parentalControlServicesService) Create(ctx context.Context, request *Cr
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), parentalControlServicesAPIPath)
 	req, err := s.client.newRequest(http.MethodPut, path, request.ParentalControlServices)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to create a parental control services")
+		return fmt.Errorf("error creating request to create a parental control services: %w", err)
 	}
 
 	response := parentalControlServicesResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to create a parental control services")
+		return fmt.Errorf("error making a request to create a parental control services: %w", err)
 	}
 
 	return nil
@@ -85,13 +83,13 @@ func (s *parentalControlServicesService) List(ctx context.Context, request *List
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), parentalControlServicesAPIPath)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to list the parental control services")
+		return nil, fmt.Errorf("error creating request to list the parental control services: %w", err)
 	}
 
 	response := parentalControlServicesResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to list the parental control services")
+		return nil, fmt.Errorf("error making a request to list the parental control services: %w", err)
 	}
 
 	return response.ParentalControlServices, nil
@@ -102,13 +100,13 @@ func (s *parentalControlServicesService) Update(ctx context.Context, request *Up
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), parentalControlServicesIDAPIPath(request.ID))
 	req, err := s.client.newRequest(http.MethodPatch, path, request.ParentalControlServices)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to update the parental control services")
+		return fmt.Errorf("error creating request to update the parental control services: %w", err)
 	}
 
 	response := parentalControlServicesResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to update the parental control services")
+		return fmt.Errorf("error making a request to update the parental control services: %w", err)
 	}
 
 	return nil

--- a/nextdns/privacy.go
+++ b/nextdns/privacy.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // privacyAPIPath is the HTTP path for the privacy settings API.
@@ -61,13 +59,13 @@ func (s *privacyService) Get(ctx context.Context, request *GetPrivacyRequest) (*
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), privacyAPIPath)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to get the privacy")
+		return nil, fmt.Errorf("error creating request to get the privacy: %w", err)
 	}
 
 	response := privacyResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to get the privacy")
+		return nil, fmt.Errorf("error making a request to get the privacy: %w", err)
 	}
 
 	return response.Privacy, nil
@@ -78,13 +76,13 @@ func (s *privacyService) Update(ctx context.Context, request *UpdatePrivacyReque
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), privacyAPIPath)
 	req, err := s.client.newRequest(http.MethodPatch, path, request.Privacy)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to update the privacy")
+		return fmt.Errorf("error creating request to update the privacy: %w", err)
 	}
 
 	response := privacyResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to update the privacy")
+		return fmt.Errorf("error making a request to update the privacy: %w", err)
 	}
 
 	return nil

--- a/nextdns/privacy_blocklists.go
+++ b/nextdns/privacy_blocklists.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // privacyBlocklistsAPIPath is the HTTP path for the privacy blocklist API.
@@ -63,13 +61,13 @@ func (s *privacyBlocklistsService) Create(ctx context.Context, request *CreatePr
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), privacyBlocklistsAPIPath)
 	req, err := s.client.newRequest(http.MethodPut, path, request.PrivacyBlocklists)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to create a privacy blocklist")
+		return fmt.Errorf("error creating request to create a privacy blocklist: %w", err)
 	}
 
 	response := privacyBlocklistsResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to create a privacy blocklist")
+		return fmt.Errorf("error making a request to create a privacy blocklist: %w", err)
 	}
 
 	return nil
@@ -80,13 +78,13 @@ func (s *privacyBlocklistsService) List(ctx context.Context, request *ListPrivac
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), privacyBlocklistsAPIPath)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to list the privacy blocklist")
+		return nil, fmt.Errorf("error creating request to list the privacy blocklist: %w", err)
 	}
 
 	response := privacyBlocklistsResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to list the privacy blocklist")
+		return nil, fmt.Errorf("error making a request to list the privacy blocklist: %w", err)
 	}
 
 	return response.PrivacyBlocklists, nil

--- a/nextdns/privacy_natives.go
+++ b/nextdns/privacy_natives.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // privacyNativesAPIPath is the HTTP path for the privacy native tracking protection API.
@@ -58,13 +56,13 @@ func (s *privacyNativesService) Create(ctx context.Context, request *CreatePriva
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), privacyNativesAPIPath)
 	req, err := s.client.newRequest(http.MethodPut, path, request.PrivacyNatives)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to create a privacy native list")
+		return fmt.Errorf("error creating request to create a privacy native list: %w", err)
 	}
 
 	response := privacyNativesResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to create a privacy native list")
+		return fmt.Errorf("error making a request to create a privacy native list: %w", err)
 	}
 
 	return nil
@@ -75,13 +73,13 @@ func (s *privacyNativesService) List(ctx context.Context, request *ListPrivacyNa
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), privacyNativesAPIPath)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to list the privacy native list")
+		return nil, fmt.Errorf("error creating request to list the privacy native list: %w", err)
 	}
 
 	response := privacyNativesResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to list the privacy native list")
+		return nil, fmt.Errorf("error making a request to list the privacy native list: %w", err)
 	}
 
 	return response.PrivacyNatives, nil

--- a/nextdns/profiles.go
+++ b/nextdns/profiles.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // profilesService is the HTTP path for the profiles API.
@@ -112,13 +110,13 @@ func NewProfilesService(client *Client) *profilesService {
 func (s *profilesService) List(ctx context.Context, request *ListProfileRequest) ([]*Profiles, error) {
 	req, err := s.client.newRequest(http.MethodGet, profilesAPIPath, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to list the profiles")
+		return nil, fmt.Errorf("error creating request to list the profiles")
 	}
 
 	response := profilesResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to list the profiles")
+		return nil, fmt.Errorf("error making a request to list the profiles")
 	}
 
 	return response.Profiles, nil
@@ -128,13 +126,13 @@ func (s *profilesService) List(ctx context.Context, request *ListProfileRequest)
 func (s *profilesService) Create(ctx context.Context, request *CreateProfileRequest) (string, error) {
 	req, err := s.client.newRequest(http.MethodPost, profilesAPIPath, request)
 	if err != nil {
-		return "", errors.Wrap(err, "error creating request to create a profile")
+		return "", fmt.Errorf("error creating request to create a profile: %w", err)
 	}
 
 	response := &newProfileResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return "", errors.Wrap(err, "error making a request to create a profile")
+		return "", fmt.Errorf("error making a request to create a profile: %w", err)
 	}
 
 	return response.Profile.ID, nil
@@ -145,13 +143,13 @@ func (s *profilesService) Update(ctx context.Context, request *UpdateProfileRequ
 	path := fmt.Sprintf("%s/%s", profilesAPIPath, request.ProfileID)
 	req, err := s.client.newRequest(http.MethodPatch, path, request.Profile)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to update the profile")
+		return fmt.Errorf("error creating request to update the profile: %w", err)
 	}
 
 	response := profileResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to update the profile")
+		return fmt.Errorf("error making a request to update the profile: %w", err)
 	}
 
 	return nil
@@ -162,13 +160,13 @@ func (s *profilesService) Get(ctx context.Context, request *GetProfileRequest) (
 	path := fmt.Sprintf("%s/%s", profilesAPIPath, request.ProfileID)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to get the profile")
+		return nil, fmt.Errorf("error creating request to get the profile: %w", err)
 	}
 
 	response := profileResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to get the profile")
+		return nil, fmt.Errorf("error making a request to get the profile: %w", err)
 	}
 
 	return response.Profile, nil
@@ -179,12 +177,12 @@ func (s *profilesService) Delete(ctx context.Context, request *DeleteProfileRequ
 	path := fmt.Sprintf("%s/%s", profilesAPIPath, request.ProfileID)
 	req, err := s.client.newRequest(http.MethodDelete, path, nil)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to delete the profile")
+		return fmt.Errorf("error creating request to delete the profile: %w", err)
 	}
 
 	err = s.client.do(ctx, req, nil)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to delete the profile")
+		return fmt.Errorf("error making a request to delete the profile: %w", err)
 	}
 
 	return err

--- a/nextdns/profiles.go
+++ b/nextdns/profiles.go
@@ -110,13 +110,13 @@ func NewProfilesService(client *Client) *profilesService {
 func (s *profilesService) List(ctx context.Context, request *ListProfileRequest) ([]*Profiles, error) {
 	req, err := s.client.newRequest(http.MethodGet, profilesAPIPath, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error creating request to list the profiles")
+		return nil, fmt.Errorf("error creating request to list the profiles: %w", err)
 	}
 
 	response := profilesResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, fmt.Errorf("error making a request to list the profiles")
+		return nil, fmt.Errorf("error making a request to list the profiles: %w", err)
 	}
 
 	return response.Profiles, nil

--- a/nextdns/rewrites.go
+++ b/nextdns/rewrites.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // rewritesAPIPath is the HTTP path for the rewrites API.
@@ -74,13 +72,13 @@ func (s *rewritesService) Create(ctx context.Context, request *CreateRewritesReq
 
 	req, err := s.client.newRequest(http.MethodPost, path, request.Rewrites)
 	if err != nil {
-		return "", errors.Wrap(err, "error creating request to create a rewrite")
+		return "", fmt.Errorf("error creating request to create a rewrite: %w", err)
 	}
 
 	response := &createRewritesResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return "", errors.Wrap(err, "error making a request to create a rewrite")
+		return "", fmt.Errorf("error making a request to create a rewrite: %w", err)
 	}
 
 	return response.Rewrites.ID, nil
@@ -91,13 +89,13 @@ func (s *rewritesService) List(ctx context.Context, request *ListRewritesRequest
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), rewritesAPIPath)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to list the rewrite list")
+		return nil, fmt.Errorf("error creating request to list the rewrite list: %w", err)
 	}
 
 	response := rewritesResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to list the rewrite list")
+		return nil, fmt.Errorf("error making a request to list the rewrite list: %w", err)
 	}
 
 	return response.Rewrites, nil
@@ -108,12 +106,12 @@ func (s *rewritesService) Delete(ctx context.Context, request *DeleteRewritesReq
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), rewritesIDAPIPath(request.ID))
 	req, err := s.client.newRequest(http.MethodDelete, path, nil)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to delete the rewrite")
+		return fmt.Errorf("error creating request to delete the rewrite: %w", err)
 	}
 
 	err = s.client.do(ctx, req, nil)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to delete the rewrite")
+		return fmt.Errorf("error making a request to delete the rewrite: %w", err)
 	}
 
 	return err

--- a/nextdns/security.go
+++ b/nextdns/security.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // securityAPIPath is the HTTP path for the security API.
@@ -70,13 +68,13 @@ func (s *securityService) Get(ctx context.Context, request *GetSecurityRequest) 
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), securityAPIPath)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to get the security settings")
+		return nil, fmt.Errorf("error creating request to get the security settings: %w", err)
 	}
 
 	response := securityResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to get the security settings")
+		return nil, fmt.Errorf("error making a request to get the security settings: %w", err)
 	}
 
 	return response.Security, nil
@@ -87,13 +85,13 @@ func (s *securityService) Update(ctx context.Context, request *UpdateSecurityReq
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), securityAPIPath)
 	req, err := s.client.newRequest(http.MethodPatch, path, request.Security)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to update the security settings")
+		return fmt.Errorf("error creating request to update the security settings: %w", err)
 	}
 
 	response := securityResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to update the security settings")
+		return fmt.Errorf("error making a request to update the security settings: %w", err)
 	}
 
 	return nil

--- a/nextdns/security_tlds.go
+++ b/nextdns/security_tlds.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // securityTldsAPIPath is the HTTP path for the security TLDs API.
@@ -58,13 +56,13 @@ func (s *securityTldsService) Create(ctx context.Context, request *CreateSecurit
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), securityTldsAPIPath)
 	req, err := s.client.newRequest(http.MethodPut, path, request.SecurityTlds)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to create a security tlds list")
+		return fmt.Errorf("error creating request to create a security tlds list: %w", err)
 	}
 
 	response := securityTldsResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to create a security tlds list")
+		return fmt.Errorf("error making a request to create a security tlds list: %w", err)
 	}
 
 	return nil
@@ -75,13 +73,13 @@ func (s *securityTldsService) List(ctx context.Context, request *ListSecurityTld
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), securityTldsAPIPath)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to list the security tlds list")
+		return nil, fmt.Errorf("error creating request to list the security tlds list: %w", err)
 	}
 
 	response := securityTldsResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to list the security tlds list")
+		return nil, fmt.Errorf("error making a request to list the security tlds list: %w", err)
 	}
 
 	return response.SecurityTlds, nil

--- a/nextdns/settings.go
+++ b/nextdns/settings.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // settingsAPIPath is the HTTP path for the settings API.
@@ -61,13 +59,13 @@ func (s *settingsService) Get(ctx context.Context, request *GetSettingsRequest) 
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), settingsAPIPath)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to get the settings")
+		return nil, fmt.Errorf("error creating request to get the settings: %w", err)
 	}
 
 	response := settingsResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to get the settings")
+		return nil, fmt.Errorf("error making a request to get the settings: %w", err)
 	}
 
 	return response.Settings, nil
@@ -78,13 +76,13 @@ func (s *settingsService) Update(ctx context.Context, request *UpdateSettingsReq
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), settingsAPIPath)
 	req, err := s.client.newRequest(http.MethodPatch, path, request.Settings)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to update the settings")
+		return fmt.Errorf("error creating request to update the settings: %w", err)
 	}
 
 	response := settingsResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to update the settings")
+		return fmt.Errorf("error making a request to update the settings: %w", err)
 	}
 
 	return nil

--- a/nextdns/settings_blockpage.go
+++ b/nextdns/settings_blockpage.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // settingsBlockPageAPIPath is the HTTP path for the settings block page API.
@@ -58,13 +56,13 @@ func (s *settingsBlockPageService) Get(ctx context.Context, request *GetSettings
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), settingsBlockPageAPIPath)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to get the block page settings")
+		return nil, fmt.Errorf("error creating request to get the block page settings: %w", err)
 	}
 
 	response := settingsBlockPageResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to get the block page settings")
+		return nil, fmt.Errorf("error making a request to get the block page settings: %w", err)
 	}
 
 	return response.SettingsBlockPage, nil
@@ -75,13 +73,13 @@ func (s *settingsBlockPageService) Update(ctx context.Context, request *UpdateSe
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), settingsBlockPageAPIPath)
 	req, err := s.client.newRequest(http.MethodPatch, path, request.SettingsBlockPage)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to update the block page settings")
+		return fmt.Errorf("error creating request to update the block page settings: %w", err)
 	}
 
 	response := settingsBlockPageResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to update the block page settings")
+		return fmt.Errorf("error making a request to update the block page settings: %w", err)
 	}
 
 	return nil

--- a/nextdns/settings_logs.go
+++ b/nextdns/settings_logs.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // settingsLogsAPIPath is the HTTP path for the settings logs API.
@@ -67,13 +65,13 @@ func (s *settingsLogsService) Get(ctx context.Context, request *GetSettingsLogsR
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), settingsLogsAPIPath)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to get the logs settings")
+		return nil, fmt.Errorf("error creating request to get the logs settings: %w", err)
 	}
 
 	response := settingsLogsResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to get the logs settings")
+		return nil, fmt.Errorf("error making a request to get the logs settings: %w", err)
 	}
 
 	return response.SettingsLogs, nil
@@ -84,13 +82,13 @@ func (s *settingsLogsService) Update(ctx context.Context, request *UpdateSetting
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), settingsLogsAPIPath)
 	req, err := s.client.newRequest(http.MethodPatch, path, request.SettingsLogs)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to update the logs settings")
+		return fmt.Errorf("error creating request to update the logs settings: %w", err)
 	}
 
 	response := settingsLogsResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to update the logs settings")
+		return fmt.Errorf("error making a request to update the logs settings: %w", err)
 	}
 
 	return nil

--- a/nextdns/settings_performance.go
+++ b/nextdns/settings_performance.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // settingsPerformanceAPIPath is the HTTP path for the settings performance API.
@@ -60,13 +58,13 @@ func (s *settingsPerformanceService) Get(ctx context.Context, request *GetSettin
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), settingsPerformanceAPIPath)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to get the performance settings")
+		return nil, fmt.Errorf("error creating request to get the performance settings: %w", err)
 	}
 
 	response := settingsPerformanceResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to get the performance settings")
+		return nil, fmt.Errorf("error making a request to get the performance settings: %w", err)
 	}
 
 	return response.SettingsPerformance, nil
@@ -77,13 +75,13 @@ func (s *settingsPerformanceService) Update(ctx context.Context, request *Update
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), settingsPerformanceAPIPath)
 	req, err := s.client.newRequest(http.MethodPatch, path, request.SettingsPerformance)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to update the performance settings")
+		return fmt.Errorf("error creating request to update the performance settings: %w", err)
 	}
 
 	response := settingsPerformanceResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to update the performance settings")
+		return fmt.Errorf("error making a request to update the performance settings: %w", err)
 	}
 
 	return nil

--- a/nextdns/setup.go
+++ b/nextdns/setup.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // setupAPIPath is the HTTP path for the setup API.
@@ -54,13 +52,13 @@ func (s *setupService) Get(ctx context.Context, request *GetSetupRequest) (*Setu
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), setupAPIPath)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to get the setup settings")
+		return nil, fmt.Errorf("error creating request to get the setup settings: %w", err)
 	}
 
 	response := setupResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to get the setup settings")
+		return nil, fmt.Errorf("error making a request to get the setup settings: %w", err)
 	}
 
 	return response.Setup, nil

--- a/nextdns/setup_linkedip.go
+++ b/nextdns/setup_linkedip.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // setupLinkedIPAPIPath is the HTTP path for the setup linked IP API.
@@ -60,13 +58,13 @@ func (s *setupLinkedIPService) Get(ctx context.Context, request *GetSetupLinkedI
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), setupLinkedIPAPIPath)
 	req, err := s.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating request to get the setup linked ip settings")
+		return nil, fmt.Errorf("error creating request to get the setup linked ip settings: %w", err)
 	}
 
 	response := setupLinkedIPResponse{}
 	err = s.client.do(ctx, req, &response)
 	if err != nil {
-		return nil, errors.Wrap(err, "error making a request to get the setup linked ip settings")
+		return nil, fmt.Errorf("error making a request to get the setup linked ip settings: %w", err)
 	}
 
 	return response.SetupLinkedIP, nil
@@ -77,12 +75,12 @@ func (s *setupLinkedIPService) Update(ctx context.Context, request *UpdateSetupL
 	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), setupLinkedIPAPIPath)
 	req, err := s.client.newRequest(http.MethodPatch, path, request.SetupLinkedIP)
 	if err != nil {
-		return errors.Wrap(err, "error creating request to update the setup linked ip settings")
+		return fmt.Errorf("error creating request to update the setup linked ip settings: %w", err)
 	}
 
 	err = s.client.do(ctx, req, nil)
 	if err != nil {
-		return errors.Wrap(err, "error making a request to update the setup linked ip settings")
+		return fmt.Errorf("error making a request to update the setup linked ip settings: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
The standard library now has built-in support for wrapping and unwrapping error values.

This change replaces all uses of `github.com/pkg/errors` with the standard library since the former is now deprecated.